### PR TITLE
Use host-built libnlua0.so when running host luajit

### DIFF
--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -61,6 +61,10 @@ termux_step_host_build() {
 	make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PKG_HOSTBUILD_DIR -DUSE_BUNDLED_LUAROCKS=ON" install ||
 		(_patch_luv $TERMUX_PKG_SRCDIR/.deps && make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$TERMUX_PKG_HOSTBUILD_DIR -DUSE_BUNDLED_LUAROCKS=ON" install)
 
+	# Copy away host-built libnlua0.so used by src/nvim/generators/preload.lua.
+	# We patch src/nvim/CMakeLists.txt to use this instead of the cross-compiled one.
+	cp ./build/lib/libnlua0.so $TERMUX_PKG_HOSTBUILD_DIR/
+
 	make distclean
 	rm -Rf build/
 

--- a/packages/neovim/build.sh
+++ b/packages/neovim/build.sh
@@ -2,14 +2,13 @@ TERMUX_PKG_HOMEPAGE=https://neovim.io/
 TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility (nvim)"
 TERMUX_PKG_LICENSE="Apache-2.0, VIM License"
 TERMUX_PKG_LICENSE_FILE="LICENSE.txt"
-TERMUX_PKG_MAINTAINER="@termux"
-TERMUX_PKG_VERSION="0.9.5"
-TERMUX_PKG_REVISION=1
+TERMUX_PKG_MAINTAINER="Joshua Kahn @TomJo2000"
+TERMUX_PKG_VERSION="0.10.0"
 TERMUX_PKG_SRCURL=https://github.com/neovim/neovim/archive/v${TERMUX_PKG_VERSION}.tar.gz
-TERMUX_PKG_SHA256=fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719
+TERMUX_PKG_SHA256=372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828
 TERMUX_PKG_AUTO_UPDATE=true
 TERMUX_PKG_UPDATE_VERSION_REGEXP="^\d+\.\d+\.\d+$"
-TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libandroid-support, libvterm (>= 1:0.3-0), libtermkey, libluajit, libunibilium, libtreesitter"
+TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libvterm (>= 1:0.3-0), libluajit, libunibilium, libtreesitter, libandroid-support, lua51-lpeg"
 TERMUX_PKG_HOSTBUILD=true
 
 TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
@@ -19,6 +18,7 @@ TERMUX_PKG_EXTRA_CONFIGURE_ARGS="
 -DPKG_CONFIG_EXECUTABLE=$(command -v pkg-config)
 -DXGETTEXT_PRG=$(command -v xgettext)
 -DLUAJIT_INCLUDE_DIR=$TERMUX_PREFIX/include/luajit-2.1
+-DLPEG_LIBRARY=$TERMUX_PREFIX/lib/liblpeg-5.1.so
 -DCOMPILE_LUA=OFF
 "
 TERMUX_PKG_CONFFILES="share/nvim/sysinit.vim"

--- a/packages/neovim/runtime-CMakeLists.txt.patch
+++ b/packages/neovim/runtime-CMakeLists.txt.patch
@@ -1,21 +1,22 @@
-diff -u -r ../neovim-0.3.2/runtime/CMakeLists.txt ./runtime/CMakeLists.txt
---- ../neovim-0.3.2/runtime/CMakeLists.txt	2018-12-31 00:06:17.000000000 +0000
-+++ ./runtime/CMakeLists.txt	2019-01-03 00:07:55.652628776 +0000
-@@ -32,7 +32,7 @@
-     add_custom_target("${PACKNAME}-tags"
+diff --git a/runtime/CMakeLists.txt b/runtime/CMakeLists.txt
+index c171fab9e..fb87d04c4 100644
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -33,7 +33,7 @@ foreach(PACKAGE ${PACKAGES})
+     add_custom_command(OUTPUT "${GENERATED_PACKAGE_DIR}/${PACKNAME}/doc/tags"
        COMMAND ${CMAKE_COMMAND} -E copy_directory
          ${PACKAGE} ${GENERATED_PACKAGE_DIR}/${PACKNAME}
--      COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"
+-      COMMAND $<TARGET_FILE:nvim_bin>
 +      COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim"
          -u NONE -i NONE -e --headless -c "helptags doc" -c quit
        DEPENDS
-         nvim
-@@ -71,7 +71,7 @@
-   COMMAND ${CMAKE_COMMAND} -E remove doc/*
+         nvim_bin
+@@ -65,7 +65,7 @@ add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
+   COMMAND ${CMAKE_COMMAND} -E remove_directory doc
    COMMAND ${CMAKE_COMMAND} -E copy_directory
      ${PROJECT_SOURCE_DIR}/runtime/doc doc
--  COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"
+-  COMMAND $<TARGET_FILE:nvim_bin>
 +  COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim"
      -u NONE -i NONE -e --headless -c "helptags ++t doc" -c quit
    DEPENDS
-     nvim
+     nvim_bin

--- a/packages/neovim/src-nvim-CMakeLists.txt.patch
+++ b/packages/neovim/src-nvim-CMakeLists.txt.patch
@@ -2,6 +2,16 @@ diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
 index 937cfaaa3..fbac79152 100644
 --- a/src/nvim/CMakeLists.txt
 +++ b/src/nvim/CMakeLists.txt
+@@ -500,8 +504,8 @@
+     "${NVIM_VERSION_DEF_H}"
+   DEPENDS "${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef-$<CONFIG>.h")
+ 
+-set(LUA_GEN ${LUA_GEN_PRG} ${GENERATOR_PRELOAD} ${PROJECT_SOURCE_DIR} $<TARGET_FILE:nlua0> ${PROJECT_BINARY_DIR})
++set(LUA_GEN ${LUA_GEN_PRG} ${GENERATOR_PRELOAD} ${PROJECT_SOURCE_DIR} "${PROJECT_BINARY_DIR}/../host-build/libnlua0.so" ${PROJECT_BINARY_DIR})
+ set(LUA_GEN_DEPS ${GENERATOR_PRELOAD} $<TARGET_FILE:nlua0>)
+ 
+ # NVIM_GENERATED_FOR_HEADERS: generated headers to be included in headers
+ # NVIM_GENERATED_FOR_SOURCES: generated headers to be included in sources
 @@ -913,7 +913,7 @@ file(GLOB LUA_SOURCES CONFIGURE_DEPENDS
  )
  

--- a/packages/neovim/src-nvim-CMakeLists.txt.patch
+++ b/packages/neovim/src-nvim-CMakeLists.txt.patch
@@ -1,0 +1,31 @@
+diff --git a/src/nvim/CMakeLists.txt b/src/nvim/CMakeLists.txt
+index 937cfaaa3..fbac79152 100644
+--- a/src/nvim/CMakeLists.txt
++++ b/src/nvim/CMakeLists.txt
+@@ -913,7 +913,7 @@ file(GLOB LUA_SOURCES CONFIGURE_DEPENDS
+ )
+ 
+ add_target(doc-vim
+-  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l scripts/gen_vimdoc.lua
++  COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -l scripts/gen_vimdoc.lua
+   DEPENDS
+     nvim
+     ${API_SOURCES}
+@@ -927,7 +927,7 @@ add_target(doc-vim
+   )
+ 
+ add_target(doc-eval
+-  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
++  COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -l ${PROJECT_SOURCE_DIR}/scripts/gen_eval_files.lua
+   DEPENDS
+     nvim
+     ${FUNCS_METADATA}
+@@ -942,7 +942,7 @@ add_custom_target(doc)
+ add_dependencies(doc doc-vim doc-eval)
+ 
+ add_target(lintdoc
+-  COMMAND $<TARGET_FILE:nvim_bin> -u NONE -l scripts/lintdoc.lua
++  COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -l scripts/lintdoc.lua
+   DEPENDS ${DOCFILES}
+   CUSTOM_COMMAND_ARGS USES_TERMINAL)
+ add_dependencies(lintdoc nvim)

--- a/packages/neovim/src-nvim-po-CMakeLists.txt.patch
+++ b/packages/neovim/src-nvim-po-CMakeLists.txt.patch
@@ -1,28 +1,28 @@
 diff --git a/src/nvim/po/CMakeLists.txt b/src/nvim/po/CMakeLists.txt
-index 1db21880b..791e833e1 100644
+index 6c2008926..75884bfff 100644
 --- a/src/nvim/po/CMakeLists.txt
 +++ b/src/nvim/po/CMakeLists.txt
-@@ -48,13 +48,13 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
+@@ -53,13 +53,13 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
    list(SORT NVIM_RELATIVE_SOURCES)
    add_custom_command(
      OUTPUT ${NVIM_POT}
--    COMMAND $<TARGET_FILE:nvim> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
 +    COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -i NONE -n --headless --cmd "set cpo+=+"
        -S ${CMAKE_CURRENT_SOURCE_DIR}/tojavascript.vim ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
      COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
        --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
        -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
        ${NVIM_RELATIVE_SOURCES} optwin.js
--    COMMAND $<TARGET_FILE:nvim> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
 +    COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -i NONE -n --headless --cmd "set cpo+=+"
        -S ${CMAKE_CURRENT_SOURCE_DIR}/fixfilenames.vim ${NVIM_POT} ../../../runtime/optwin.vim
      VERBATIM
-     DEPENDS ${NVIM_SOURCES} nvim nvim_runtime_deps)
-@@ -83,7 +83,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
+     DEPENDS ${NVIM_SOURCES} nvim_bin nvim_runtime_deps)
+@@ -88,7 +88,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
      set(poFile ${CMAKE_CURRENT_SOURCE_DIR}/${name}.po)
  
      add_custom_target(check-po-${name}
--      COMMAND $<TARGET_FILE:nvim> -u NONE -n -e
+-      COMMAND $<TARGET_FILE:nvim_bin> -u NONE -n -e
 +      COMMAND "${PROJECT_BINARY_DIR}/../host-build/bin/nvim" -u NONE -n -e
            -S ${CMAKE_CURRENT_SOURCE_DIR}/check.vim
            -c "if error == 0 | q | endif" -c cq ${poFile} ||


### PR DESCRIPTION
This should fix the remaining build error in https://github.com/termux/termux-packages/pull/20273

As it modifies the host build, if there exists an existing neovim `0.10` PR host build, one needs to `rm -Rf ~/.termux-build/neovim/host-build/` in the build environment to force a fresh neovim `0.10` host build locally.